### PR TITLE
 Fix compatibility with php8

### DIFF
--- a/ykksm-utils.php
+++ b/ykksm-utils.php
@@ -33,7 +33,7 @@ function yubi_hex2bin($h)
   if (!is_string($h)) return null;
   $r='';
   for ($a=0; $a<strlen($h); $a+=2) {
-    $r.=chr(hexdec($h{$a}.$h{($a+1)}));
+    $r.=chr(hexdec($h[$a].$h[($a+1)]));
   }
   return $r;
 }


### PR DESCRIPTION
Hello

I tried to setup it with php8.

I got this error message : 
```console
3831#3831: *1 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /usr/share/yubikey-ksm/ykksm-utils.php on line 36" while rea
ding response header from upstream, client: ::1, server: , request: "GET /wsapi/decrypt.php?otp=ccccccdvlncufehgjirkkgnfhrkrrhnrblebciiivjug HTTP/1.1", upstream: "fastcgi://unix:/var/run/php-fpm8/php-fpm.sock:", host: "localhost"
```
So i adjust line36 in order to get te correct answer with my wget.

Before 
```console
wget -q -O - 'http://localhost/wsapi/decrypt.php?otp=xxxxxxxxxxxxxehgjirkkgnfhrkrrhnrblebciiivjug'
ERR Database error
```

After change
```console
wget -q -O - 'http://localhost/wsapi/decrypt.php?otp=xxxxxxxxxxxxxehgjirkkgnfhrkrrhnrblebciiivjug'
ERR Unknown yubikey
```